### PR TITLE
chore(deps): AWS Lambdaでアプリケーションを動かすために必要なライブラリをバージョンを固定して追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+boto3==1.35.28
+botocore==1.35.28
+fastjsonschema==2.20.0
+requests==2.32.3
+urllib3==2.2.3
+slack_sdk==3.32.0
+openai==1.51.0
+python-json-logger==2.0.7
+typing-extensions==4.12.2
+aws-lambda-powertools==2.45.0
+


### PR DESCRIPTION
## 概要
AWS Lambdaでアプリケーションを動作させるために必要なPythonライブラリの依存関係を固定バージョンで追加しました。

## 変更内容
- `requirements.txt`を新規作成
- 以下のライブラリを固定バージョンで追加：
  - `boto3==1.35.28` - AWS SDK
  - `botocore==1.35.28` - AWS SDK core
  - `fastjsonschema==2.20.0` - JSON schema validation
  - `requests==2.32.3` - HTTP library
  - `urllib3==2.2.3` - HTTP client
  - `slack_sdk==3.32.0` - Slack API client
  - `openai==1.51.0` - OpenAI API client
  - `python-json-logger==2.0.7` - JSON logging
  - `typing-extensions==4.12.2` - Type hints extensions
  - `aws-lambda-powertools==2.45.0` - Lambda utilities

## 目的
- 本番環境での依存関係の安定性を確保
- 再現可能なビルド環境の構築
- セキュリティアップデートの管理を容易化

## 影響範囲
- 新規ファイル追加のみ（既存コードへの影響なし）