### PR TITLE
infra(terraform): Terraformの基本的な設定の雛形とMakefileのコマンドを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,25 @@
+# Python
+__pycache__/
+*.pyc
+.venv/
+
+# Terraform
+.terraform/
+.terraform.*
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+terraform.tfvars
+*.auto.tfvars
+
+# Local env/config
+.env
+.env.*
+.DS_Store
 # Obsidian
 .obsidian/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+TF_DIR=infra/terraform
+
+.PHONY: tf-init tf-workspace tf-plan tf-apply tf-destroy
+
+tf-init:
+	cd $(TF_DIR) && terraform init -upgrade
+
+tf-workspace:
+	cd $(TF_DIR) && terraform workspace list | cat
+
+tf-plan:
+	cd $(TF_DIR) && terraform plan
+
+tf-apply:
+	cd $(TF_DIR) && terraform apply -auto-approve
+
+tf-destroy:
+	cd $(TF_DIR) && terraform destroy -auto-approve
+

--- a/infra/terraform/backend.auto.tfvars.example
+++ b/infra/terraform/backend.auto.tfvars.example
@@ -1,0 +1,5 @@
+tf_state_bucket           = "your-tf-state-bucket-name"
+tf_state_key_prefix       = "reply-bot"
+tf_state_dynamodb_table   = "your-tf-locks-table"
+aws_region                = "ap-northeast-1"
+

--- a/infra/terraform/backend.tf.json
+++ b/infra/terraform/backend.tf.json
@@ -1,0 +1,15 @@
+{
+  "terraform": {
+    "backend": {
+      "s3": {
+        "bucket": "${var.tf_state_bucket}",
+        "key": "${var.tf_state_key_prefix}/${terraform.workspace}.tfstate",
+        "region": "${var.aws_region}",
+        "dynamodb_table": "${var.tf_state_dynamodb_table}",
+        "encrypt": true
+      }
+    }
+  }
+}
+
+

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "reply-bot"
+      Environment = terraform.workspace
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region to deploy resources into"
+  default     = "ap-northeast-1"
+}
+
+variable "tf_state_bucket" {
+  type        = string
+  description = "S3 bucket name for Terraform remote state"
+}
+
+variable "tf_state_key_prefix" {
+  type        = string
+  description = "Key prefix for Terraform state objects"
+  default     = "infra/root"
+}
+
+variable "tf_state_dynamodb_table" {
+  type        = string
+  description = "DynamoDB table for Terraform state locking"
+}
+
+


### PR DESCRIPTION
## 概要

Terraformの基本的な設定とバックエンドプロバイダーの雛形を追加し、インフラストラクチャ管理の基盤を構築しました。

### 主な変更内容

- **Terraform設定ファイルの追加**
  - `providers.tf`: AWSプロバイダーの設定とバージョン制約
  - `backend.tf.json`: S3バックエンドとDynamoDBロックテーブルの設定
  - `variables.tf`: 必要な変数の定義（リージョン、S3バケット、DynamoDBテーブル等）
  - `backend.auto.tfvars.example`: 設定例ファイル

- **開発効率化のためのMakefile追加**
  - `tf-init`, `tf-plan`, `tf-apply`, `tf-destroy`等のコマンドを定義
  - ワークスペース管理コマンドも含む

- **Gitignore設定の更新**
  - Terraform関連ファイルの除外設定を追加