### PR TITLE
infra(dynamodb): contextテーブルを追加し、SSE, PITR, TTLを有効化

### DIFF
--- a/infra/terraform/dynamodb.tf
+++ b/infra/terraform/dynamodb.tf
@@ -1,0 +1,25 @@
+resource "aws_dynamodb_table" "context" {
+  name         = local.effective_ddb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "context_id"
+
+  attribute {
+    name = "context_id"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = local.effective_ddb_ttl_attr
+    enabled        = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+}
+
+

--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  default_ddb_table_name = "reply-bot-context-${terraform.workspace}"
+  default_ddb_ttl_attr   = "ttl_epoch"
+
+  effective_ddb_table_name = length(trim(var.ddb_table_name)) > 0 ? var.ddb_table_name : local.default_ddb_table_name
+  effective_ddb_ttl_attr   = length(trim(var.ddb_ttl_attribute)) > 0 ? var.ddb_ttl_attribute : local.default_ddb_ttl_attr
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -20,4 +20,16 @@ variable "tf_state_dynamodb_table" {
   description = "DynamoDB table for Terraform state locking"
 }
 
+variable "ddb_table_name" {
+  type        = string
+  description = "DynamoDB table name for workflow context (default derived from workspace if empty)"
+  default     = ""
+}
+
+variable "ddb_ttl_attribute" {
+  type        = string
+  description = "TTL attribute name for DynamoDB items"
+  default     = ""
+}
+
 


### PR DESCRIPTION
## 概要

reply-botアプリケーションのワークフローコンテキスト管理用DynamoDBテーブルを追加し、データの自動削除（TTL）、暗号化、バックアップ機能を有効化しました。

### 主な変更内容

- **DynamoDBテーブルの作成**
  - テーブル名: `reply-bot-context-{workspace}`
  - プライマリキー: `context_id` (String型)
  - 課金モード: オンデマンド（PAY_PER_REQUEST）

- **セキュリティ・可用性機能の有効化**
  - **TTL（Time To Live）**: 自動データ削除機能を有効化
  - **サーバーサイド暗号化（SSE）**: データの暗号化を有効化
  - **ポイントインタイムリカバリ（PITR）**: データのバックアップ・復旧機能を有効化

- **設定の柔軟性向上**
  - `ddb_table_name`: テーブル名のカスタマイズ可能
  - `ddb_ttl_attribute`: TTL属性名のカスタマイズ可能
  - デフォルト値: `ttl_epoch`属性でTTL管理