### PR TITLE
infra(sqs,lambda): 処理失敗メッセージを補足するデッドレターキュー(DLQ)を追加

### DIFF
--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -65,6 +65,18 @@ data "aws_iam_policy_document" "lambda_app_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid = "SQS"
+    actions = [
+      "sqs:SendMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl"
+    ]
+    resources = [
+      aws_sqs_queue.dlq.arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "lambda_app" {

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -1,0 +1,28 @@
+data "archive_file" "lambda_package" {
+  type        = "zip"
+  source_dir  = "${path.root}/../../src/lambda"
+  output_path = "${path.module}/.dist/lambda.zip"
+}
+
+resource "aws_lambda_function" "app" {
+  function_name = "reply-bot-${terraform.workspace}"
+  role          = aws_iam_role.lambda_exec.arn
+  runtime       = "python3.11"
+  handler       = "handler.handler"
+
+  filename         = data.archive_file.lambda_package.output_path
+  source_code_hash = data.archive_file.lambda_package.output_base64sha256
+
+  timeout     = 30
+  memory_size = 256
+
+  environment {
+    variables = {
+      STAGE = terraform.workspace
+    }
+  }
+
+  dead_letter_config {
+    target_arn = aws_sqs_queue.dlq.arn
+  }
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4.0"
+    }
   }
 
   backend "s3" {}

--- a/infra/terraform/sqs.tf
+++ b/infra/terraform/sqs.tf
@@ -1,0 +1,18 @@
+resource "aws_sqs_queue" "dlq" {
+  name                      = "reply-bot-dlq-${terraform.workspace}"
+  message_retention_seconds = 1209600 # 14 days
+  sqs_managed_sse_enabled   = true
+}
+
+resource "aws_sqs_queue" "main" {
+  name                      = "reply-bot-queue-${terraform.workspace}"
+  message_retention_seconds = 345600 # 4 days
+  sqs_managed_sse_enabled   = true
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.dlq.arn
+    maxReceiveCount     = 3
+  })
+}
+
+


### PR DESCRIPTION
## 概要

reply-botアプリケーションの非同期処理とエラーハンドリングを強化するため、SQSキュー、デッドレターキュー（DLQ）、Lambda関数のインフラストラクチャを追加しました。

### 主な変更内容

- **SQSキューの設定**
  - **メインキュー**: `reply-bot-queue-{workspace}`
    - メッセージ保持期間: 4日間
    - 最大受信回数: 3回（失敗時はDLQに移動）
  - **デッドレターキュー（DLQ）**: `reply-bot-dlq-{workspace}`
    - メッセージ保持期間: 14日間
    - 処理失敗メッセージの補足・分析用

- **Lambda関数の設定**
  - 関数名: `reply-bot-{workspace}`
  - ランタイム: Python 3.11
  - タイムアウト: 30秒、メモリ: 256MB
  - デッドレター設定: DLQへの自動転送

- **セキュリティ機能**
  - SQS管理型SSE暗号化を有効化
  - Lambda関数のDLQ設定によるエラー処理の自動化

- **IAM権限の追加**
  - SQS操作権限（SendMessage, GetQueueAttributes, GetQueueUrl）
  - Archiveプロバイダーの追加（Lambdaパッケージング用）