### PR TITLE
infra(ses): 受信メールをLambdaで処理するためのルールと権限を追加

### DIFF
--- a/infra/terraform/ses.tf
+++ b/infra/terraform/ses.tf
@@ -1,0 +1,44 @@
+variable "ses_rule_set_name" {
+  type        = string
+  description = "SES active receipt rule set name"
+  default     = "reply-bot-rule-set"
+}
+
+variable "ses_recipients" {
+  type        = list(string)
+  description = "List of recipient email addresses to match"
+  default     = ["support@your-reply-domain.com"]
+}
+
+resource "aws_ses_receipt_rule_set" "main" {
+  rule_set_name = var.ses_rule_set_name
+}
+
+resource "aws_ses_active_receipt_rule_set" "active" {
+  rule_set_name = aws_ses_receipt_rule_set.main.rule_set_name
+}
+
+resource "aws_ses_receipt_rule" "lambda_route" {
+  name          = "route-to-lambda"
+  rule_set_name = aws_ses_receipt_rule_set.main.rule_set_name
+  enabled       = true
+  recipients    = var.ses_recipients
+  scan_enabled  = true
+  tls_policy    = "Optional"
+
+  lambda_action {
+    function_arn    = aws_lambda_function.app.arn
+    invocation_type = "Event"
+    position        = 1
+  }
+}
+
+resource "aws_lambda_permission" "allow_ses_invoke" {
+  statement_id  = "AllowExecutionFromSES"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.app.function_name
+  principal     = "ses.amazonaws.com"
+  source_arn    = aws_ses_receipt_rule.lambda_route.arn
+}
+
+


### PR DESCRIPTION
## 概要

reply-botアプリケーションのメール受信処理を自動化するため、SESの受信ルールセットとLambda関数への自動転送機能を追加しました。

### 主な変更内容

- **SES受信ルールセットの設定**
  - ルールセット名: `reply-bot-rule-set`
  - アクティブルールセットとして設定

- **受信ルールの設定**
  - ルール名: `route-to-lambda`
  - 受信者フィルタ: カスタマイズ可能（デフォルト: `support@your-reply-domain.com`）
  - スキャン機能: 有効化（ウイルス・スパム検出）
  - TLSポリシー: Optional

- **Lambda関数との連携**
  - 受信メールの自動Lambda関数呼び出し
  - 呼び出しタイプ: Event（非同期処理）
  - SESからのLambda実行権限を付与

- **セキュリティ設定**
  - Lambda関数へのSES実行権限を最小限に制限
  - 特定の受信ルールからのみ実行可能