### PR TITLE
infra(apigw): Slack Events APIからのPOSTリクエストをLambdaに連携するエンドポイントを追加

### DIFF
--- a/infra/terraform/apigw.tf
+++ b/infra/terraform/apigw.tf
@@ -1,0 +1,35 @@
+resource "aws_apigatewayv2_api" "http" {
+  name          = "reply-bot-http-${terraform.workspace}"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.http.id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  integration_uri        = aws_lambda_function.app.invoke_arn
+  payload_format_version = "2.0"
+  timeout_milliseconds   = 29000
+}
+
+resource "aws_apigatewayv2_route" "slack_events" {
+  api_id    = aws_apigatewayv2_api.http.id
+  route_key = "POST /slack/events"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.http.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "allow_apigw_invoke" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.app.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.http.execution_arn}/*/POST/slack/events"
+}
+
+


### PR DESCRIPTION
## 概要

Slack Events APIからのWebhookイベントを受信し、reply-botアプリケーションで処理するためのAPI Gatewayエンドポイントを追加。

### 主な変更内容

- **HTTP API Gatewayの設定**
  - API名: `reply-bot-http-{workspace}`
  - プロトコル: HTTP API v2
  - 自動デプロイ機能を有効化

- **Slack Events APIエンドポイント**
  - ルート: `POST /slack/events`
  - Lambda関数との統合設定（AWS_PROXY）
  - ペイロード形式: 2.0
  - タイムアウト: 29秒

- **Lambda関数との連携**
  - 統合タイプ: AWS_PROXY（完全なリクエスト/レスポンス転送）
  - API GatewayからのLambda実行権限を付与
  - 特定のエンドポイントからのみ実行可能

- **セキュリティ設定**
  - 最小権限の原則に基づく実行権限
  - ワークスペース別のリソース分離