### PR TITLE
chore(tfvars,make): Terraformの環境構築を効率化する設定サンプルとmakeコマンドを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,16 @@ layer-presidio:
 	pip install -q presidio-analyzer presidio-anonymizer -t layers/presidio/python/lib/python3.11/site-packages
 	cd $(TF_DIR) && terraform fmt -recursive
 
+.PHONY: plan-staging apply-staging plan-prod apply-prod
+plan-staging:
+	cd $(TF_DIR) && terraform workspace select staging || terraform workspace new staging; terraform init -upgrade; terraform plan -var-file=staging.tfvars
+
+apply-staging:
+	cd $(TF_DIR) && terraform workspace select staging || terraform workspace new staging; terraform init -upgrade; terraform apply -auto-approve -var-file=staging.tfvars
+
+plan-prod:
+	cd $(TF_DIR) && terraform workspace select prod || terraform workspace new prod; terraform init -upgrade; terraform plan -var-file=prod.tfvars
+
+apply-prod:
+	cd $(TF_DIR) && terraform workspace select prod || terraform workspace new prod; terraform init -upgrade; terraform apply -auto-approve -var-file=prod.tfvars
+

--- a/infra/terraform/prod.tfvars.example
+++ b/infra/terraform/prod.tfvars.example
@@ -1,0 +1,17 @@
+aws_region = "ap-northeast-1"
+
+tf_state_bucket         = "<your-terraform-state-bucket>"
+tf_state_key_prefix     = "reply-bot"
+tf_state_dynamodb_table = "<your-terraform-locks-table>"
+
+ddb_table_name      = "reply-bot-context-prod"
+ddb_ttl_attribute   = "ttl_epoch"
+
+secret_name_openai_api_key = "reply-bot/prod/openai/api-key"
+secret_name_slack_app      = "reply-bot/prod/slack/app-creds"
+
+ses_rule_set_name = "reply-bot-prod"
+ses_recipients    = ["support@example.com"]
+
+alarm_lambda_error_threshold = 1
+alarm_apigw_5xx_threshold    = 1

--- a/infra/terraform/staging.tfvars.example
+++ b/infra/terraform/staging.tfvars.example
@@ -1,0 +1,18 @@
+aws_region = "ap-northeast-1"
+
+tf_state_bucket         = "<your-terraform-state-bucket>"
+tf_state_key_prefix     = "reply-bot"
+tf_state_dynamodb_table = "<your-terraform-locks-table>"
+
+ddb_table_name      = "reply-bot-context-staging"
+ddb_ttl_attribute   = "ttl_epoch"
+
+secret_name_openai_api_key = "reply-bot/stg/openai/api-key"
+secret_name_slack_app      = "reply-bot/stg/slack/app-creds"
+
+ses_rule_set_name = "reply-bot-staging"
+ses_recipients    = ["support@example.com"]
+
+alarm_lambda_error_threshold = 1
+alarm_apigw_5xx_threshold    = 1
+


### PR DESCRIPTION
## 概要

reply-botアプリケーションの環境別デプロイメントを効率化するため、Terraformの設定サンプルファイルと環境別のMakefileコマンドを追加しました。

### 主な変更内容

- **環境別設定ファイルの追加**
  - `prod.tfvars.example`: 本番環境用の設定サンプル
  - `staging.tfvars.example`: ステージング環境用の設定サンプル
  - 各環境に適したリソース名と設定値を定義

- **Makefileコマンドの追加**
  - `plan-staging/apply-staging`: ステージング環境の計画・適用
  - `plan-prod/apply-prod`: 本番環境の計画・適用
  - ワークスペースの自動作成・選択機能

- **設定項目の標準化**
  - **インフラ設定**: S3バケット、DynamoDBテーブル、リージョン
  - **アプリケーション設定**: テーブル名、TTL属性、シークレット名
  - **SES設定**: ルールセット名、受信者アドレス
  - **監視設定**: アラーム閾値

### 運用効率化

- 環境別の設定管理の簡素化
- デプロイメント手順の標準化
- 設定ミスの防止
- 新環境構築の迅速化

### セキュリティ考慮

- 機密情報のプレースホルダー化
- 環境別のリソース分離
- 設定ファイルのテンプレート化