### PR TITLE
infra(terraform): Lambdaの環境変数を設定し、IAM権限をDynamoDBテーブルに限定

### DIFF
--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -46,7 +46,9 @@ data "aws_iam_policy_document" "lambda_app_policy" {
       "dynamodb:Query",
       "dynamodb:Scan"
     ]
-    resources = ["*"]
+    resources = [
+      aws_dynamodb_table.context.arn
+    ]
   }
 
   statement {

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -18,7 +18,10 @@ resource "aws_lambda_function" "app" {
 
   environment {
     variables = {
-      STAGE = terraform.workspace
+      STAGE                        = terraform.workspace
+      DDB_TABLE_NAME               = local.effective_ddb_table_name
+      OPENAI_API_KEY_SECRET_ARN    = aws_secretsmanager_secret.openai_api_key.arn
+      SLACK_APP_SECRET_ARN         = aws_secretsmanager_secret.slack_app.arn
     }
   }
 


### PR DESCRIPTION
## 概要

reply-botアプリケーションのLambda関数に必要な環境変数を設定し、セキュリティを強化するためDynamoDBアクセス権限を特定テーブルに限定しました。

### 主な変更内容

- **Lambda環境変数の追加**
  - `DDB_TABLE_NAME`: DynamoDBテーブル名の設定
  - `OPENAI_API_KEY_SECRET_ARN`: OpenAI APIキーのSecrets Manager ARN
  - `SLACK_APP_SECRET_ARN`: Slackアプリ認証情報のSecrets Manager ARN
  - `STAGE`: ワークスペース名（既存）

- **IAM権限の最適化**
  - DynamoDBアクセス権限をワイルドカード（`*`）から特定テーブルに限定
  - `aws_dynamodb_table.context.arn`のみにアクセス権限を制限
  - 最小権限の原則に基づくセキュリティ強化

### セキュリティ向上

- **権限の最小化**: 不要なDynamoDBテーブルへのアクセスを防止
- **環境変数による設定管理**: ハードコーディングの排除
- **Secrets Manager連携**: 機密情報の安全な管理