### PR TITLE
infra(terraform): 送信元メールとSlackチャンネルの変数を追加し、Lambdaの環境変数に設定

### DIFF
--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -22,6 +22,8 @@ resource "aws_lambda_function" "app" {
       DDB_TABLE_NAME               = local.effective_ddb_table_name
       OPENAI_API_KEY_SECRET_ARN    = aws_secretsmanager_secret.openai_api_key.arn
       SLACK_APP_SECRET_ARN         = aws_secretsmanager_secret.slack_app.arn
+      SENDER_EMAIL_ADDRESS         = var.sender_email_address
+      SLACK_CHANNEL_ID             = var.slack_channel_id
     }
   }
 

--- a/infra/terraform/prod.tfvars.example
+++ b/infra/terraform/prod.tfvars.example
@@ -13,5 +13,8 @@ secret_name_slack_app      = "reply-bot/prod/slack/app-creds"
 ses_rule_set_name = "reply-bot-prod"
 ses_recipients    = ["support@example.com"]
 
+sender_email_address = "support@your-reply-domain.com"
+slack_channel_id     = "C0PRODCHANID"
+
 alarm_lambda_error_threshold = 1
 alarm_apigw_5xx_threshold    = 1

--- a/infra/terraform/staging.tfvars.example
+++ b/infra/terraform/staging.tfvars.example
@@ -13,6 +13,9 @@ secret_name_slack_app      = "reply-bot/stg/slack/app-creds"
 ses_rule_set_name = "reply-bot-staging"
 ses_recipients    = ["support@example.com"]
 
+sender_email_address = "support@your-reply-domain.com"
+slack_channel_id     = "C01234ABCDE"
+
 alarm_lambda_error_threshold = 1
 alarm_apigw_5xx_threshold    = 1
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -32,4 +32,15 @@ variable "ddb_ttl_attribute" {
   default     = ""
 }
 
+variable "sender_email_address" {
+  type        = string
+  description = "SES sender email address used for replies"
+}
+
+variable "slack_channel_id" {
+  type        = string
+  description = "Slack channel ID for notifications"
+  default     = ""
+}
+
 


### PR DESCRIPTION
## 概要

reply-botアプリケーションのメール送信とSlack通知機能を実装するため、送信元メールアドレスとSlackチャンネルIDの設定変数を追加し、Lambda関数の環境変数に設定しました。

### 主な変更内容

- **新しい変数の追加**
  - `sender_email_address`: SES送信元メールアドレス（必須）
  - `slack_channel_id`: Slack通知用チャンネルID（オプション）

- **Lambda環境変数の拡張**
  - `SENDER_EMAIL_ADDRESS`: メール送信時の送信元アドレス
  - `SLACK_CHANNEL_ID`: 通知送信先のSlackチャンネル

- **環境別設定ファイルの更新**
  - **本番環境**: `support@your-reply-domain.com`, `C0PRODCHANID`
  - **ステージング環境**: `support@your-reply-domain.com`, `C01234ABCDE`
  - 環境に応じた適切な設定値の例示

### 機能拡張

- **メール送信機能**: 設定された送信元アドレスからの自動返信
- **Slack通知機能**: 指定チャンネルへの処理状況通知
- **環境分離**: 本番・ステージング環境での異なる設定管理

### 運用効果

- 設定の外部化による柔軟性向上
- 環境別の適切な通知先管理
- メール送信の信頼性確保
- 運用チームへの適切な通知