### PR TITLE
feat(lambda): view_submissionのフローを実装（DDB読み込み、SES送信、Slack通知）

### DIFF
--- a/src/lambda/common/config.py
+++ b/src/lambda/common/config.py
@@ -9,6 +9,8 @@ class AppConfig:
     openai_api_key_secret_arn: str
     slack_app_secret_arn: str
     ddb_table_name: str
+    sender_email_address: str
+    slack_channel_id: str
 
 
 def load_config() -> AppConfig:
@@ -18,4 +20,6 @@ def load_config() -> AppConfig:
         openai_api_key_secret_arn=os.getenv("OPENAI_API_KEY_SECRET_ARN", ""),
         slack_app_secret_arn=os.getenv("SLACK_APP_SECRET_ARN", ""),
         ddb_table_name=os.getenv("DDB_TABLE_NAME", ""),
+        sender_email_address=os.getenv("SENDER_EMAIL_ADDRESS", ""),
+        slack_channel_id=os.getenv("SLACK_CHANNEL_ID", ""),
     )

--- a/src/lambda/common/dynamodb_repo.py
+++ b/src/lambda/common/dynamodb_repo.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import boto3
+
+
+def get_table_name() -> str:
+    name = os.getenv("DDB_TABLE_NAME", "")
+    if not name:
+        raise ValueError("DDB_TABLE_NAME not set")
+    return name
+
+
+def get_context_item(context_id: str) -> Optional[Dict[str, Any]]:
+    table = boto3.resource("dynamodb").Table(get_table_name())
+    resp = table.get_item(Key={"context_id": context_id})
+    return resp.get("Item")

--- a/src/lambda/common/ses_email.py
+++ b/src/lambda/common/ses_email.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import List
+
+import boto3
+
+
+def send_email(
+    sender: str,
+    to_addresses: List[str],
+    subject: str,
+    body: str,
+) -> None:
+    client = boto3.client("ses")
+    client.send_email(
+        Source=sender,
+        Destination={"ToAddresses": to_addresses},
+        Message={
+            "Subject": {"Data": subject, "Charset": "UTF-8"},
+            "Body": {"Text": {"Data": body, "Charset": "UTF-8"}},
+        },
+    )

--- a/src/lambda/slack/client.py
+++ b/src/lambda/slack/client.py
@@ -14,6 +14,14 @@ class SlackClient:
         # Slack requires views.open within 3 seconds of interaction
         self._client.views_open(trigger_id=trigger_id, view=view)
 
+    def post_message(
+        self, channel: str, text: str, blocks: Dict[str, Any] | None = None
+    ) -> None:
+        kwargs: Dict[str, Any] = {"channel": channel, "text": text}
+        if blocks is not None:
+            kwargs["blocks"] = blocks
+        self._client.chat_postMessage(**kwargs)
+
 
 def build_ai_reply_modal(context_id: str, initial_text: str) -> Dict[str, Any]:
     # Block Kit modal per design docs with fixed IDs


### PR DESCRIPTION
## 概要

reply-botアプリケーションのSlackモーダル送信機能を実装し、DynamoDBからのコンテキスト取得、SESメール送信、Slack通知の完全なフローを構築しました。

### 主な変更内容

- **view_submissionイベント処理の実装**
  - モーダルからの編集済みテキストの取得
  - プライベートメタデータからのコンテキストID抽出
  - エラーハンドリングと適切なレスポンス

- **DynamoDBリポジトリ機能**
  - `get_context_item`: コンテキストIDによるデータ取得
  - テーブル名の環境変数管理
  - エラーハンドリングの実装

- **SESメール送信機能**
  - `send_email`: 送信元、宛先、件名、本文の設定
  - UTF-8文字エンコーディング対応
  - シンプルなテキスト形式での送信

- **Slack通知機能の拡張**
  - `post_message`: チャンネルへのメッセージ投稿
  - Block Kit形式のメッセージ対応
  - 送信完了通知の実装

- **設定管理の拡張**
  - `sender_email_address`: 送信元メールアドレス
  - `slack_channel_id`: 通知チャンネルID
  - 環境変数ベースの設定管理

### 処理フロー

1. **モーダル送信**: ユーザーが編集した返信文案を取得
2. **コンテキスト取得**: DynamoDBから元メール情報を取得
3. **メール送信**: SESを使用して返信メールを送信
4. **通知送信**: Slackチャンネルに完了通知を投稿