### PR TITLE
feat(Slack): SESイベント受信時にアクションボタン付きの新規メール通知を投稿

### DIFF
--- a/src/lambda/slack/client.py
+++ b/src/lambda/slack/client.py
@@ -54,3 +54,48 @@ def build_ai_reply_modal(context_id: str, initial_text: str) -> Dict[str, Any]:
         ],
     }
 
+
+def build_new_email_notification(
+    context_id: str,
+    sender: str,
+    subject: str,
+    preview_text: str,
+) -> Any:
+    # Block Kit message for new email notification with action button
+    try:
+        value_json = json.dumps({"context_id": context_id})
+    except Exception:
+        value_json = "{}"
+    blocks: Any = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "新しい問い合わせが届きました"},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*From:* {sender}"},
+                {"type": "mrkdwn", "text": f"*Subject:* {subject}"},
+            ],
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": preview_text,
+            },
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "返信文を生成する"},
+                    "style": "primary",
+                    "action_id": "generate_reply_action",
+                    "value": value_json,
+                }
+            ],
+        },
+    ]
+    return blocks


### PR DESCRIPTION
## 概要

reply-botアプリケーションのSES受信メール処理にSlack通知機能を追加し、新規メール受信時にアクションボタン付きの通知をSlackチャンネルに投稿する機能を実装しました。

### 主な変更内容

- **新規メール通知機能の実装**
  - `build_new_email_notification`: Block Kit形式の通知メッセージ生成
  - 送信者、件名、本文プレビューの表示
  - アクションボタン「返信文を生成する」の追加

- **Slack通知の詳細**
  - **ヘッダー**: "新しい問い合わせが届きました"
  - **メール情報**: 送信者と件名の表示
  - **本文プレビュー**: マスキング済み本文の表示（400文字制限）
  - **アクションボタン**: プライマリスタイルのボタン

- **SESイベント処理の拡張**
  - メール受信後のSlack通知送信
  - エラーハンドリングによる堅牢性確保
  - コンテキストIDの連携

- **データ処理の最適化**
  - 本文の改行文字正規化
  - プレビューテキストの長さ制限
  - マスキング済み本文の優先使用

### UX向上

- **視覚的な通知**: 構造化されたメッセージ表示
- **即座のアクション**: ワンクリックでの返信生成開始
- **情報の整理**: 重要な情報の見やすい表示
- **日本語対応**: 分かりやすい日本語UI