### PR TITLE
feat(lambda): block_actionsをトリガーにAIで下書きを生成し、モーダルに事前入力する機能の実装

### DIFF
--- a/src/lambda/common/openai_client.py
+++ b/src/lambda/common/openai_client.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+from openai import OpenAI
+
+from .config import load_config
+from .logging import log_error
+from .secrets import resolve_openai_api_key
+
+
+@lru_cache(maxsize=1)
+def _get_client() -> OpenAI:
+    cfg = load_config()
+    api_key = resolve_openai_api_key(
+        cfg.openai_api_key_secret_arn
+    )
+    return OpenAI(api_key=api_key)
+
+
+def generate_reply_draft(
+    redacted_body: str,
+    tone: Optional[str] = None,
+) -> str:
+    """
+    Generate a Japanese reply draft from redacted text.
+    Do not include PII; input is already redacted.
+    """
+    if not redacted_body:
+        return ""
+    lines = [
+        "あなたは日本語のCS担当者です。以下の問い合わせに対し、",
+        "丁寧で簡潔な返信文案を日本語で作成してください。",
+        "- 会社のブランドトーンに合う丁寧語",
+        "- 不確実な点は確認依頼として記載",
+        "- 箇条書き可",
+        "- 件名行は不要",
+        "",
+        "問い合わせ本文（機微情報はプレースホルダーに置換済み）：",
+        redacted_body,
+        "",
+    ]
+    if tone:
+        lines.append(f"希望するトーン: {tone}")
+        lines.append("")
+    prompt = "\n".join(lines)
+
+    try:
+        client = _get_client()
+        # Keep response short for latency
+        resp = client.responses.create(
+            model="gpt-4o-mini",
+            input=prompt,
+            max_output_tokens=400,
+        )
+        text = resp.output_text or ""
+        return text.strip()
+    except Exception as exc:  # pragma: no cover - external call
+        log_error("openai generation failed", error=str(exc))
+        return ""


### PR DESCRIPTION
## 概要

reply-botアプリケーションのSlackモーダル機能を拡張し、block_actionsイベント時にAIが自動生成した返信文案をモーダルに事前入力する機能を実装しました。

### 主な変更内容

- **OpenAIクライアント機能の実装**
  - `generate_reply_draft`: AIによる返信文案の自動生成
  - GPT-4o-miniモデルの使用
  - 日本語CS担当者としての返信生成
  - 最大400トークンの出力制限

- **AI返信生成の仕様**
  - **プロンプト設計**: 丁寧で簡潔な日本語返信の生成
  - **ブランドトーン**: 会社のブランドに合う丁寧語
  - **不確実な点**: 確認依頼として適切に記載
  - **箇条書き対応**: 必要に応じて箇条書き形式

- **モーダル事前入力機能**
  - 1秒以内の時間制約でのAI生成
  - マスキング済み本文からの返信生成
  - PII復元による最終文案の作成
  - エラーハンドリングによる堅牢性確保

- **処理フローの最適化**
  - 時間制約内での効率的な処理
  - フォールバック機能（生成失敗時のデフォルトテキスト）
  - コンテキスト情報の適切な取得

### 技術仕様

- **モデル**: GPT-4o-mini（低レイテンシー）
- **キャッシュ**: LRUキャッシュによる効率化
- **セキュリティ**: Secrets ManagerからのAPIキー取得
- **エラー処理**: 外部API呼び出しの堅牢な処理

### UX向上

- **即座の返信案**: ワンクリックでAI生成された返信案を表示
- **編集可能**: 生成された案を自由に編集可能
- **時間効率**: 手動での返信文案作成時間の大幅短縮
- **品質向上**: 一貫したブランドトーンでの返信