### PR TITLE
fix: Secrets ManagerのARN出力を追加

### DIFF
--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -20,3 +20,10 @@ resource "aws_secretsmanager_secret" "slack_app" {
   kms_key_id = null
 }
 
+output "secrets_openai_arn" {
+  value = aws_secretsmanager_secret.openai_api_key.arn
+}
+
+output "secrets_slack_app_arn" {
+  value = aws_secretsmanager_secret.slack_app.arn
+}


### PR DESCRIPTION
- OpenAI APIキーとSlackアプリ認証情報のSecrets Manager ARNを出力
- 他のリソースからSecrets ManagerのARNを参照可能にする
- インフラの可視性とデバッグ性を向上