### PR TITLE
fix: 機密ファイルをGit追跡から削除し、.gitignoreを強化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ staging.tfvars
 prod.tfvars
 backend.auto.tfvars
 *.local.tfvars
+# 機密情報を含む可能性のあるファイル
+*secret*
+*credential*
+*key*
+*password*
+*token*
 
 # Local env/config
 .env
@@ -73,10 +79,15 @@ node_modules/
 
 # Environment variables
 .env
+.env.*
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
+# 機密情報を含む環境変数ファイル
+config.local.*
+secrets.*
+credentials.*
 
 # Python
 __pycache__/


### PR DESCRIPTION
## 概要

機密情報を含むファイルをGit追跡から削除し、セキュリティを向上させるための修正を行いました。

## 変更内容

### 機密ファイルの追跡削除
- `infra/terraform/staging.tfvars`をGit追跡から削除
- `infra/terraform/prod.tfvars`をGit追跡から削除
- これらのファイルには実際のGmailアドレスなどの機密情報が含まれていました

### .gitignoreの強化
以下の機密情報を含む可能性のあるファイルパターンを追加：
- `*secret*` - シークレット情報を含むファイル
- `*credential*` - 認証情報を含むファイル  
- `*key*` - キー情報を含むファイル
- `*password*` - パスワード情報を含むファイル
- `*token*` - トークン情報を含むファイル
- `config.local.*` - ローカル設定ファイル
- `secrets.*` - シークレット設定ファイル
- `credentials.*` - 認証情報設定ファイル

## セキュリティ向上の効果

1. **機密情報漏洩の防止**: 実際のGmailアドレスなどの機密情報がGit履歴に残らない
2. **予防的対策**: 将来の開発で機密情報を含むファイルの誤コミットを防止
3. **設定管理の改善**: 機密情報と非機密情報の適切な分離