### PR TITLE
feat: OpenAI API機能を有効化

### DIFF
--- a/src/app/router.py
+++ b/src/app/router.py
@@ -21,8 +21,7 @@ try:
         build_new_email_notification,
     )
     from common.pii import redact_and_map, reidentify
-    # 一時的にOpenAI機能を無効化
-    # from common.openai_client import generate_reply_draft
+    from common.openai_client import generate_reply_draft
 except ImportError:
     # テスト環境用の相対インポート
     from .common.config import load_config
@@ -37,8 +36,7 @@ except ImportError:
         build_new_email_notification,
     )
     from .common.pii import redact_and_map, reidentify
-    # 一時的にOpenAI機能を無効化
-    # from .common.openai_client import generate_reply_draft
+    from .common.openai_client import generate_reply_draft
 
 
 def _response(status: int, body: Dict[str, Any]) -> Dict[str, Any]:
@@ -140,8 +138,11 @@ def handle_event(event: Dict[str, Any]) -> Dict[str, Any]:
                 except Exception:
                     pii_map = {}
                 if redacted_body and (time.time() - started) < 1.0:
-                    # 一時的にOpenAI機能を無効化
-                    draft = "AI返信生成機能は一時的に無効化されています。"
+                    try:
+                        draft = generate_reply_draft(redacted_body)
+                    except Exception as exc:
+                        log_error("openai generation failed", error=str(exc))
+                        draft = ""
                     if draft:
                         try:
                             initial_text = reidentify(draft, pii_map)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -88,6 +88,7 @@ class TestIntegration:
             patch("src.app.router.resolve_slack_credentials") as mock_creds,
             patch("src.app.router.verify_slack_signature") as mock_verify,
             patch("src.app.router.get_context_item") as mock_get,
+            patch("src.app.router.generate_reply_draft") as mock_generate,
             patch("src.app.router.reidentify") as mock_reidentify,
             patch("src.app.router.SlackClient") as mock_slack,
         ):
@@ -105,7 +106,7 @@ class TestIntegration:
                 "body_redacted": "Hello, I have a question about your service.",
                 "pii_map": "{}"
             }
-            # mock_generate is no longer needed as OpenAI functionality is disabled
+            mock_generate.return_value = "Thank you for your inquiry. We will get back to you soon."
             mock_reidentify.return_value = "Thank you for your inquiry. We will get back to you soon."
             mock_slack_instance = MagicMock()
             mock_slack.return_value = mock_slack_instance

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -89,6 +89,7 @@ class TestEventRouter:
             ) as mock_creds,
             patch("src.app.router.verify_slack_signature") as mock_verify,
             patch("src.app.router.get_context_item") as mock_get,
+            patch("src.app.router.generate_reply_draft") as mock_generate,
             patch("src.app.router.reidentify") as mock_reidentify,
             patch("src.app.router.SlackClient") as mock_slack,
         ):
@@ -106,7 +107,7 @@ class TestEventRouter:
                 "signing_secret": "s"
             }
             mock_get.return_value = {"body_redacted": "red", "pii_map": "{}"}
-            # mock_generate is no longer needed as OpenAI functionality is disabled
+            mock_generate.return_value = "Generated reply"
             mock_reidentify.return_value = "Generated reply"
             mock_slack_instance = MagicMock()
             mock_slack.return_value = mock_slack_instance


### PR DESCRIPTION
 - 目的
    - OpenAI APIを用いた返信文案生成を有効化し、Slack上のHITLフローで下書きを提示できるようにする。
  - 主な変更
    - `router.py`: `generate_reply_draft`を再有効化。OpenAIクライアント未導入時はNOOPにフォールバック。
    - `openai_client.py`: Secrets ManagerからAPIキー読込、`responses.create`で下書き生成。
    - Terraform: Lambdaの環境変数にOpenAIキーのSecret ARNを設定。
    - テスト: `generate_reply_draft`をモックしてルーティングとUI動作を検証。
  - 設定/運用
    - Secrets Managerに`reply-bot/stg/openai/api-key`を登録済み（実キー必要）。
    - `terraform apply -var-file=staging.tfvars`で反映。
  - 影響範囲
    - 既存Slack通知フローに変更なし。OpenAI未導入環境でもエラーにならず動作継続。
  - 今後
    - Gmail受信対応は別ブランチ`feature/gmail-inbound`で実装予定（Gmail必須要件対応）。