### PR TITLE
feat(terraform): GmailポーラーLambdaとEventBridgeスケジュール、Gmail OAuthシークレット追加

### DIFF
--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -58,7 +58,8 @@ data "aws_iam_policy_document" "lambda_app_policy" {
     ]
     resources = [
       aws_secretsmanager_secret.openai_api_key.arn,
-      aws_secretsmanager_secret.slack_app.arn
+      aws_secretsmanager_secret.slack_app.arn,
+      aws_secretsmanager_secret.gmail_oauth.arn
     ]
   }
 

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "app" {
       SLACK_APP_SECRET_ARN         = aws_secretsmanager_secret.slack_app.arn
       SENDER_EMAIL_ADDRESS         = var.sender_email_address
       SLACK_CHANNEL_ID             = var.slack_channel_id
+      GMAIL_OAUTH_SECRET_ARN       = aws_secretsmanager_secret.gmail_oauth.arn
     }
   }
 
@@ -34,4 +35,53 @@ resource "aws_lambda_function" "app" {
   dead_letter_config {
     target_arn = aws_sqs_queue.dlq.arn
   }
+}
+
+# Gmail Poller Lambda (shares same source package, different handler)
+resource "aws_lambda_function" "gmail_poller" {
+  function_name = "reply-bot-gmail-poller-${terraform.workspace}"
+  role          = aws_iam_role.lambda_exec.arn
+  runtime       = "python3.11"
+  handler       = "gmail_poller.handler"
+
+  filename         = data.archive_file.lambda_package.output_path
+  source_code_hash = data.archive_file.lambda_package.output_base64sha256
+
+  timeout     = 30
+  memory_size = 256
+
+  environment {
+    variables = {
+      STAGE                        = terraform.workspace
+      DDB_TABLE_NAME               = local.effective_ddb_table_name
+      OPENAI_API_KEY_SECRET_ARN    = aws_secretsmanager_secret.openai_api_key.arn
+      SLACK_APP_SECRET_ARN         = aws_secretsmanager_secret.slack_app.arn
+      SENDER_EMAIL_ADDRESS         = var.sender_email_address
+      SLACK_CHANNEL_ID             = var.slack_channel_id
+      GMAIL_OAUTH_SECRET_ARN       = aws_secretsmanager_secret.gmail_oauth.arn
+    }
+  }
+
+  layers = [
+    aws_lambda_layer_version.presidio.arn
+  ]
+}
+
+resource "aws_cloudwatch_event_rule" "gmail_poll_schedule" {
+  name                = "reply-bot-gmail-poll-${terraform.workspace}"
+  schedule_expression = "rate(2 minutes)"
+}
+
+resource "aws_cloudwatch_event_target" "gmail_poll_target" {
+  rule      = aws_cloudwatch_event_rule.gmail_poll_schedule.name
+  target_id = "gmail-poller"
+  arn       = aws_lambda_function.gmail_poller.arn
+}
+
+resource "aws_lambda_permission" "allow_events_invoke_gmail_poller" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.gmail_poller.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.gmail_poll_schedule.arn
 }

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -10,6 +10,12 @@ variable "secret_name_slack_app" {
   default     = "reply-bot/slack/app-creds"
 }
 
+variable "secret_name_gmail_oauth" {
+  type        = string
+  description = "Secrets Manager name for Gmail OAuth credentials"
+  default     = "reply-bot/gmail/oauth"
+}
+
 resource "aws_secretsmanager_secret" "openai_api_key" {
   name       = var.secret_name_openai_api_key
   kms_key_id = null
@@ -17,6 +23,11 @@ resource "aws_secretsmanager_secret" "openai_api_key" {
 
 resource "aws_secretsmanager_secret" "slack_app" {
   name       = var.secret_name_slack_app
+  kms_key_id = null
+}
+
+resource "aws_secretsmanager_secret" "gmail_oauth" {
+  name       = var.secret_name_gmail_oauth
   kms_key_id = null
 }
 

--- a/src/app/common/config.py
+++ b/src/app/common/config.py
@@ -11,6 +11,7 @@ class AppConfig:
     ddb_table_name: str
     sender_email_address: str
     slack_channel_id: str
+    gmail_oauth_secret_arn: str
 
 
 def load_config() -> AppConfig:
@@ -22,4 +23,5 @@ def load_config() -> AppConfig:
         ddb_table_name=os.getenv("DDB_TABLE_NAME", ""),
         sender_email_address=os.getenv("SENDER_EMAIL_ADDRESS", ""),
         slack_channel_id=os.getenv("SLACK_CHANNEL_ID", ""),
+        gmail_oauth_secret_arn=os.getenv("GMAIL_OAUTH_SECRET_ARN", ""),
     )


### PR DESCRIPTION
- 説明:
  - 目的: Gmail APIでUNREADを定期取得し、既存HITLフローに載せるための基盤を追加
  - 変更:
    - Secrets Manager: `reply-bot/gmail/oauth`
    - Lambda: `reply-bot-gmail-poller-<env>`（`gmail_poller.handler`）
    - EventBridge: `rate(2 minutes)`で起動
    - IAM: Secrets/DynamoDB/Logs 権限にGmail OAuth追加
    - 環境変数: `GMAIL_OAUTH_SECRET_ARN` を各Lambdaに追加
  - セットアップ:
    - `aws secretsmanager put-secret-value --secret-id reply-bot/gmail/oauth --secret-string '{"client_id":"...", "client_secret":"...", "refresh_token":"..."}'`
  - 影響範囲: 本体Lambdaへの破壊的変更なし（環境変数追加のみ）
  - 今後: 重複防止（DynamoDB記録）、ユニットテスト、ドキュメント整備