### PR TITLE
feat(terraform): Slack Signing Secret をSecrets/IAM/Lambdaに統合し、-var-file運用へ移行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,26 @@ wheels/
 # AWS
 .aws/
 .obsidian/workspace.json
+
+# Locally vendored libraries for Lambda
+src/app/apiclient/
+src/app/cachetools/
+src/app/certifi/
+src/app/charset_normalizer/
+src/app/google/
+src/app/google_auth_httplib2.py
+src/app/google_auth_oauthlib/
+src/app/googleapiclient/
+src/app/httplib2/
+src/app/idna/
+src/app/oauthlib/
+src/app/proto/
+src/app/pyasn1/
+src/app/pyasn1_modules/
+src/app/pyparsing/
+src/app/requests/
+src/app/requests_oauthlib/
+src/app/rsa/
+src/app/slack_sdk/
+src/app/uritemplate/
+src/app/urllib3/

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -59,7 +59,8 @@ data "aws_iam_policy_document" "lambda_app_policy" {
     resources = [
       aws_secretsmanager_secret.openai_api_key.arn,
       aws_secretsmanager_secret.slack_app.arn,
-      aws_secretsmanager_secret.gmail_oauth.arn
+      aws_secretsmanager_secret.gmail_oauth.arn,
+      aws_secretsmanager_secret.slack_signing.arn
     ]
   }
 

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -22,6 +22,7 @@ resource "aws_lambda_function" "app" {
       DDB_TABLE_NAME               = local.effective_ddb_table_name
       OPENAI_API_KEY_SECRET_ARN    = aws_secretsmanager_secret.openai_api_key.arn
       SLACK_APP_SECRET_ARN         = aws_secretsmanager_secret.slack_app.arn
+      SLACK_SIGNING_SECRET_ARN     = aws_secretsmanager_secret.slack_signing.arn
       SENDER_EMAIL_ADDRESS         = var.sender_email_address
       SLACK_CHANNEL_ID             = var.slack_channel_id
       GMAIL_OAUTH_SECRET_ARN       = aws_secretsmanager_secret.gmail_oauth.arn
@@ -56,6 +57,7 @@ resource "aws_lambda_function" "gmail_poller" {
       DDB_TABLE_NAME               = local.effective_ddb_table_name
       OPENAI_API_KEY_SECRET_ARN    = aws_secretsmanager_secret.openai_api_key.arn
       SLACK_APP_SECRET_ARN         = aws_secretsmanager_secret.slack_app.arn
+      SLACK_SIGNING_SECRET_ARN     = aws_secretsmanager_secret.slack_signing.arn
       SENDER_EMAIL_ADDRESS         = var.sender_email_address
       SLACK_CHANNEL_ID             = var.slack_channel_id
       GMAIL_OAUTH_SECRET_ARN       = aws_secretsmanager_secret.gmail_oauth.arn

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -31,3 +31,15 @@ resource "aws_secretsmanager_secret" "gmail_oauth" {
   kms_key_id = null
 }
 
+# Slack signing secret
+variable "secret_name_slack_signing" {
+  type        = string
+  description = "Secrets Manager name for Slack signing secret"
+  default     = "reply-bot/slack/signing-secret"
+}
+
+resource "aws_secretsmanager_secret" "slack_signing" {
+  name       = var.secret_name_slack_signing
+  kms_key_id = null
+}
+


### PR DESCRIPTION
- 概要
  - SlackのSigning SecretをAWS Secrets Managerで管理し、IAMポリシーで許可し、Lambda環境変数へ配線しました。
  - Terraform実行を`-var-file=staging.tfvars`前提に整理し、環境変数の空値上書きリスクを解消。

- 主な変更点
  - `infra/terraform/secrets.tf`:
    - `aws_secretsmanager_secret.slack_signing`を追加（`reply-bot/slack/signing-secret`）
  - `infra/terraform/iam.tf`:
    - Lambda実行ポリシーに`slack_signing`の`secretsmanager:GetSecretValue`を追加
  - `infra/terraform/lambda.tf`:
    - 両Lambdaに`SLACK_SIGNING_SECRET_ARN`を環境変数として追加
  - 既存Secrets（OpenAI/Slack App）をTerraform stateへインポートし、リソース名と整合

- 運用変更
  - Terraformは常に`-var-file=staging.tfvars`（本番は`-var-file=prod.tfvars`）で実行
  - Signing Secretは`reply-bot/slack/signing-secret`に保存し、Lambdaから参照

- 確認事項
  - Secrets Manager:
    - `reply-bot/slack/signing-secret` に値が投入済み（ステージング）
    - `reply-bot/stg/slack/app-creds`, `reply-bot/stg/openai/api-key` 正常
  - 両Lambdaの環境変数に`SLACK_SIGNING_SECRET_ARN`が設定されていること
  - Gmailポーラー手動実行で未読取得→Slack通知の動作確認済み

- 影響範囲
  - Lambda環境変数とIAMポリシー（最小権限の範囲内）
  - インフラ構成（Secretsリソース増加）

- リスク/ロールバック
  - リスク: `-var-file`未指定運用に戻すと再び空値上書きの恐れ
  - ロールバック: 本PRをリバート後、以前のSecrets/環境変数に戻す

- テスト
  - `terraform init/plan/apply`（staging）成功
  - Secrets投入後、Gmail未読→Slack通知のE2E確認