### PR TITLE
feat: 非同期生成エンドポイント設定の対応

### DIFF
--- a/ASYNC_ENDPOINT_SETUP.md
+++ b/ASYNC_ENDPOINT_SETUP.md
@@ -1,0 +1,179 @@
+# 非同期生成エンドポイント設定ガイド
+
+このガイドでは、Cloud Runデプロイ後に`async_generation_endpoint`と`async_generation_auth_header`を設定する手順を説明します。
+
+## 前提条件
+
+- Cloud Runサービスがデプロイ済み
+- GCPプロジェクトでTerraformが実行済み
+- AWS Lambda側のTerraformが実行可能
+
+## 設定手順
+
+### ステップ1: Cloud Run URLの取得
+
+```bash
+# GCP Terraformディレクトリに移動
+cd infra/terraform/gcp
+
+# Cloud RunサービスのURLを取得
+CLOUDRUN_URL=$(terraform output -raw cloud_run_service_url)
+echo "Cloud Run URL: $CLOUDRUN_URL"
+
+# 非同期生成エンドポイントのURLを構築
+ASYNC_ENDPOINT="${CLOUDRUN_URL}/async/generate"
+echo "Async Endpoint: $ASYNC_ENDPOINT"
+```
+
+### ステップ2: 認証トークンの取得
+
+```bash
+# GCP Secret Managerから認証トークンを取得
+AUTH_TOKEN=$(gcloud secrets versions access latest --secret="reply-bot-auth-token-staging")
+echo "Auth Token: $AUTH_TOKEN"
+```
+
+### ステップ3: AWS Lambda設定の更新
+
+```bash
+# AWS Terraformディレクトリに移動
+cd ../../
+
+# staging.tfvarsを編集
+cat > staging.tfvars << EOF
+aws_region = "ap-northeast-1"
+
+# Terraform state configuration
+tf_state_bucket         = "reply-bot-terraform-state-20241224"
+tf_state_key_prefix     = "reply-bot"
+tf_state_dynamodb_table = "reply-bot-terraform-state-lock"
+
+# DynamoDB configuration
+ddb_table_name      = "reply-bot-context-staging"
+ddb_ttl_attribute   = "ttl_epoch"
+
+# Secrets Manager configuration
+secret_name_openai_api_key = "reply-bot/stg/openai/api-key"
+secret_name_slack_app      = "reply-bot/stg/slack/app-creds"
+
+# SES configuration
+ses_rule_set_name = "reply-bot-rule-set"
+ses_recipients    = ["hirotaka19990821@gmail.com"]
+
+# Application configuration
+sender_email_address = "hirotaka19990821@gmail.com"
+slack_channel_id     = "C09H7V2BFNG"
+
+# Monitoring configuration
+alarm_lambda_error_threshold = 1
+alarm_apigw_5xx_threshold    = 1
+
+# Cloud Run async generation configuration
+async_generation_endpoint = "${ASYNC_ENDPOINT}"
+async_generation_auth_header = "Bearer ${AUTH_TOKEN}"
+EOF
+
+# Terraform applyを実行
+terraform apply -var-file=staging.tfvars
+```
+
+### ステップ4: Slack Request URLの更新
+
+```bash
+# Slack Bot Tokenを取得（Secrets Managerから）
+SLACK_BOT_TOKEN=$(aws secretsmanager get-secret-value \
+  --secret-id "reply-bot/stg/slack/app-creds" \
+  --query 'SecretString' --output text | jq -r '.bot_token')
+
+# Slack Request URLを更新
+./scripts/update-slack-request-url.sh \
+  -e staging \
+  -u "$CLOUDRUN_URL" \
+  -t "$SLACK_BOT_TOKEN"
+```
+
+### ステップ5: 動作確認
+
+```bash
+# デプロイメント検証スクリプトを実行
+./scripts/validate-deployment.sh staging
+
+# Cloud Runサービスのヘルスチェック
+curl -f "${CLOUDRUN_URL}/health" || echo "Health check failed"
+
+# 非同期生成エンドポイントのテスト
+curl -X POST "${ASYNC_ENDPOINT}" \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"context_id": "test", "external_id": "test-modal", "stage": "staging"}' \
+  -v
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+1. **Cloud Run URLが取得できない**
+   ```bash
+   # GCPプロジェクトが正しく設定されているか確認
+   gcloud config get-value project
+   
+   # Terraformの状態を確認
+   cd infra/terraform/gcp
+   terraform show
+   ```
+
+2. **認証トークンが取得できない**
+   ```bash
+   # Secret Managerのシークレット一覧を確認
+   gcloud secrets list --filter="name:reply-bot"
+   
+   # シークレットの詳細を確認
+   gcloud secrets describe reply-bot-auth-token-staging
+   ```
+
+3. **Slack Request URL更新が失敗する**
+   ```bash
+   # Slack Bot Tokenが正しいか確認
+   curl -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+     "https://slack.com/api/auth.test"
+   
+   # アプリのマニフェストを確認
+   curl -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+     "https://slack.com/api/apps.manifest.get" | jq '.'
+   ```
+
+### ログの確認
+
+```bash
+# Cloud Runサービスのログを確認
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=reply-bot-slack-events-staging" --limit=50
+
+# AWS Lambdaのログを確認
+aws logs describe-log-groups --log-group-name-prefix "/aws/lambda/reply-bot-staging"
+```
+
+## 設定値の確認
+
+設定が正しく反映されているか確認するには：
+
+```bash
+# AWS Lambdaの環境変数を確認
+aws lambda get-function-configuration \
+  --function-name reply-bot-staging \
+  --query 'Environment.Variables.{ASYNC_GENERATION_ENDPOINT:ASYNC_GENERATION_ENDPOINT,ASYNC_GENERATION_AUTH_HEADER:ASYNC_GENERATION_AUTH_HEADER}'
+
+# Cloud Runサービスの環境変数を確認
+gcloud run services describe reply-bot-slack-events-staging \
+  --region=asia-northeast1 \
+  --format="value(spec.template.spec.template.spec.containers[0].env[].name,spec.template.spec.template.spec.containers[0].env[].value)"
+```
+
+## 次のステップ
+
+設定完了後は以下を実行してください：
+
+1. **E2Eテスト**: 実際のSlackボタンクリックで非同期生成が動作するか確認
+2. **モニタリング**: CloudWatchとGCP Loggingでエラーがないか確認
+3. **パフォーマンス**: 生成時間とレスポンス時間を測定
+4. **本番環境**: 同様の手順で本番環境にも適用

--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -34,13 +34,49 @@ cd infra/terraform
 
 ## 🔧 デプロイメント手順
 
-### **ステップ1: Terraformの初期化**
+### **ステップ1: Cloud Runデプロイ（非同期生成対応）**
+```bash
+# Cloud Runコンポーネントをデプロイ
+cd infra/terraform/gcp
+terraform init
+terraform workspace select staging
+terraform apply -var-file=staging.tfvars
+
+# デプロイ後のURLを取得
+CLOUDRUN_URL=$(terraform output -raw cloud_run_service_url)
+echo "Cloud Run URL: $CLOUDRUN_URL"
+```
+
+### **ステップ2: AWS Lambda設定の更新**
+```bash
+# AWS側のTerraformを更新（async_generation_endpointを設定）
+cd ../../
+terraform init
+terraform workspace select staging
+
+# staging.tfvarsにCloud Run URLを設定
+# async_generation_endpoint = "https://your-cloudrun-url/async/generate"
+# async_generation_auth_header = "Bearer your-auth-token"
+
+terraform apply -var-file=staging.tfvars
+```
+
+### **ステップ3: Slack Request URL更新**
+```bash
+# SlackアプリのRequest URLをCloud Runに更新
+./scripts/update-slack-request-url.sh \
+  -e staging \
+  -u "$CLOUDRUN_URL" \
+  -t "your-slack-bot-token"
+```
+
+### **ステップ4: 従来のTerraform初期化（参考）**
 ```bash
 cd infra/terraform
 terraform init
 ```
 
-### **ステップ2: ワークスペースの設定**
+### **ステップ5: ワークスペースの設定**
 ```bash
 # ステージング環境
 terraform workspace select staging
@@ -49,7 +85,7 @@ terraform workspace select staging
 terraform workspace select prod
 ```
 
-### **ステップ3: 設定ファイルの確認**
+### **ステップ6: 設定ファイルの確認**
 ```bash
 # ステージング環境の設定を確認
 cat staging.tfvars
@@ -58,23 +94,23 @@ cat staging.tfvars
 cat prod.tfvars
 ```
 
-### **ステップ4: インフラの計画確認**
+### **ステップ8: インフラの計画確認**
 ```bash
 terraform plan -var-file=staging.tfvars
 ```
 
-### **ステップ5: インフラのデプロイ**
+### **ステップ9: インフラのデプロイ**
 ```bash
 terraform apply -var-file=staging.tfvars
 ```
 
-### **ステップ6: Secrets Managerの設定**
+### **ステップ10: Secrets Managerの設定**
 ```bash
 # スクリプトを使用してSecrets Managerに認証情報を設定
 ./scripts/setup-secrets.sh staging --interactive
 ```
 
-### **ステップ7: Slackアプリの設定**
+### **ステップ11: Slackアプリの設定**
 1. [Slack API管理画面](https://api.slack.com/apps)にアクセス
 2. 新しいアプリを作成
 3. Bot Token Scopesを設定：
@@ -82,11 +118,11 @@ terraform apply -var-file=staging.tfvars
    - `chat:write.public`
    - `commands`
 4. Interactivity & Shortcutsを有効化
-5. Request URLを設定：`https://[API_GATEWAY_URL]/slack/events`
+5. Request URLを設定：`https://[CLOUDRUN_URL]/slack/events`（Cloud Runデプロイ後）
 6. Event Subscriptionsを有効化
 7. アプリをワークスペースにインストール
 
-### **ステップ8: デプロイメントの検証**
+### **ステップ12: デプロイメントの検証**
 ```bash
 # 検証スクリプトを実行
 ./scripts/validate-deployment.sh staging

--- a/infra/terraform/staging.tfvars.example
+++ b/infra/terraform/staging.tfvars.example
@@ -19,3 +19,8 @@ slack_channel_id     = "C01234ABCDE"
 alarm_lambda_error_threshold = 1
 alarm_apigw_5xx_threshold    = 1
 
+# Cloud Run async generation configuration
+# 注意: Cloud Runデプロイ後に実際のURLに更新してください
+async_generation_endpoint = "https://your-cloudrun-service-url/async/generate"
+async_generation_auth_header = "Bearer your-auth-token"
+

--- a/scripts/update-slack-request-url.sh
+++ b/scripts/update-slack-request-url.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# Slack Request URL更新スクリプト
+# Cloud Runデプロイ後にSlackアプリのRequest URLを更新する
+
+set -euo pipefail
+
+# 設定
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+TERRAFORM_DIR="$PROJECT_ROOT/infra/terraform"
+
+# 色付きログ
+log_info() {
+    echo -e "\033[32m[INFO]\033[0m $1"
+}
+
+log_warn() {
+    echo -e "\033[33m[WARN]\033[0m $1"
+}
+
+log_error() {
+    echo -e "\033[31m[ERROR]\033[0m $1"
+}
+
+# 使用方法
+usage() {
+    cat << EOF
+使用方法: $0 [OPTIONS]
+
+SlackアプリのRequest URLを更新します。
+
+OPTIONS:
+    -e, --environment ENV    環境名 (staging|prod) [デフォルト: staging]
+    -u, --url URL           Cloud RunサービスのURL
+    -t, --token TOKEN       Slack App Token
+    -h, --help              このヘルプを表示
+
+例:
+    $0 -e staging -u https://reply-bot-slack-events-staging-xxxxx-uc.a.run.app -t xoxb-xxxxx
+    $0 --environment prod --url https://reply-bot-slack-events-prod-xxxxx-uc.a.run.app --token xoxb-xxxxx
+
+EOF
+}
+
+# デフォルト値
+ENVIRONMENT="staging"
+CLOUDRUN_URL=""
+SLACK_TOKEN=""
+
+# 引数解析
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -e|--environment)
+            ENVIRONMENT="$2"
+            shift 2
+            ;;
+        -u|--url)
+            CLOUDRUN_URL="$2"
+            shift 2
+            ;;
+        -t|--token)
+            SLACK_TOKEN="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_error "不明なオプション: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# 必須パラメータチェック
+if [[ -z "$CLOUDRUN_URL" ]]; then
+    log_error "Cloud Run URLが指定されていません"
+    usage
+    exit 1
+fi
+
+if [[ -z "$SLACK_TOKEN" ]]; then
+    log_error "Slack Tokenが指定されていません"
+    usage
+    exit 1
+fi
+
+# 環境チェック
+if [[ "$ENVIRONMENT" != "staging" && "$ENVIRONMENT" != "prod" ]]; then
+    log_error "環境は 'staging' または 'prod' である必要があります"
+    exit 1
+fi
+
+log_info "Slack Request URL更新を開始します"
+log_info "環境: $ENVIRONMENT"
+log_info "Cloud Run URL: $CLOUDRUN_URL"
+
+# Slack Request URL構築
+SLACK_REQUEST_URL="${CLOUDRUN_URL}/slack/events"
+
+log_info "新しいRequest URL: $SLACK_REQUEST_URL"
+
+# Slack APIでRequest URLを更新
+log_info "Slack APIでRequest URLを更新中..."
+
+# Slack Appの情報を取得
+APP_INFO=$(curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+    "https://slack.com/api/apps.manifest.get")
+
+if echo "$APP_INFO" | jq -e '.ok' > /dev/null; then
+    log_info "現在のSlack App情報を取得しました"
+else
+    log_error "Slack App情報の取得に失敗しました"
+    echo "$APP_INFO" | jq '.'
+    exit 1
+fi
+
+# 現在のマニフェストを取得
+CURRENT_MANIFEST=$(echo "$APP_INFO" | jq '.manifest')
+
+# Request URLを更新
+UPDATED_MANIFEST=$(echo "$CURRENT_MANIFEST" | jq --arg url "$SLACK_REQUEST_URL" '
+    .event_subscriptions.request_url = $url |
+    .interactivity.request_url = $url
+')
+
+# マニフェストを更新
+UPDATE_RESULT=$(curl -s -X POST \
+    -H "Authorization: Bearer $SLACK_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"manifest\": $UPDATED_MANIFEST}" \
+    "https://slack.com/api/apps.manifest.update")
+
+if echo "$UPDATE_RESULT" | jq -e '.ok' > /dev/null; then
+    log_info "Slack Request URLの更新が完了しました"
+    log_info "更新されたURL: $SLACK_REQUEST_URL"
+else
+    log_error "Slack Request URLの更新に失敗しました"
+    echo "$UPDATE_RESULT" | jq '.'
+    exit 1
+fi
+
+# 検証: 更新されたURLを確認
+log_info "更新結果を検証中..."
+VERIFY_RESULT=$(curl -s -H "Authorization: Bearer $SLACK_TOKEN" \
+    "https://slack.com/api/apps.manifest.get")
+
+if echo "$VERIFY_RESULT" | jq -e '.ok' > /dev/null; then
+    CURRENT_URL=$(echo "$VERIFY_RESULT" | jq -r '.manifest.event_subscriptions.request_url')
+    if [[ "$CURRENT_URL" == "$SLACK_REQUEST_URL" ]]; then
+        log_info "✅ Request URLの更新が正常に完了しました"
+        log_info "現在のURL: $CURRENT_URL"
+    else
+        log_warn "⚠️  Request URLが期待値と異なります"
+        log_warn "期待値: $SLACK_REQUEST_URL"
+        log_warn "実際値: $CURRENT_URL"
+    fi
+else
+    log_error "更新結果の検証に失敗しました"
+    echo "$VERIFY_RESULT" | jq '.'
+    exit 1
+fi
+
+log_info "Slack Request URL更新が完了しました"


### PR DESCRIPTION
- staging.tfvars.exampleにasync_generation_*変数を追加
- Slack Request URL更新スクリプトを追加
- デプロイメント手順をCloud Run対応に更新
- 詳細な設定ガイドを追加