### PR TITLE
feat: Cloud Runサービスのイングレス設定を追加

### DIFF
--- a/infra/terraform/gcp/cloudrun.tf
+++ b/infra/terraform/gcp/cloudrun.tf
@@ -7,6 +7,10 @@ resource "google_cloud_run_v2_service" "slack_events" {
   template {
     service_account = google_service_account.cloudrun.email
     
+    annotations = {
+      "run.googleapis.com/ingress" = "all"
+    }
+    
     containers {
       image = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.reply_bot.name}/slack-events:latest"
       


### PR DESCRIPTION
- Cloud Runサービスにrun.googleapis.com/ingressアノテーションを追加
- 外部からのアクセスを許可するための設定
- staging.tfvarsにAWS Workload Identity連携用の変数を追加